### PR TITLE
Final styling

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,7 @@
 <div class="app">
   <div class='app-heading-container'>
-    <img src="https://imgur.com/G7H5fHS.jpg" class='app-logo'>
+    <img src="https://imgur.com/U90tGAa.jpg" class='app-logo'>
+    <!-- <img src="https://imgur.com/G7H5fHS.jpg" class='app-logo'> -->
     <h1 class='app-title'>Wellth Water</h1>
   </div>
   <div class='app-horizontal-flex'>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,6 @@
 <div class="app">
   <div class='app-heading-container'>
     <img src="https://imgur.com/U90tGAa.jpg" class='app-logo'>
-    <!-- <img src="https://imgur.com/G7H5fHS.jpg" class='app-logo'> -->
     <h1 class='app-title'>Wellth Water</h1>
   </div>
   <div class='app-horizontal-flex'>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -29,7 +29,8 @@
   font-family: Cabin Sketch;
   color: #62B6CB;
   margin: 0px;
-  text-shadow: 3px 3px 2px white;
+  // text-shadow: 3px 3px 2px white;
   margin-top: -40px;
   padding-bottom: 5px;
+  font-weight: normal;
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -29,7 +29,6 @@
   font-family: Cabin Sketch;
   color: #62B6CB;
   margin: 0px;
-  // text-shadow: 3px 3px 2px white;
   margin-top: -40px;
   padding-bottom: 5px;
   font-weight: normal;

--- a/src/app/logpane/logpane.component.scss
+++ b/src/app/logpane/logpane.component.scss
@@ -41,6 +41,5 @@ p, h2 {
 .total-text {
   font-size: 60px;
   color: #62B6CB;
-  // text-shadow: 2px 2px 2px white;
   font-family: Cabin Sketch;
 }

--- a/src/app/logpane/logpane.component.scss
+++ b/src/app/logpane/logpane.component.scss
@@ -41,6 +41,6 @@ p, h2 {
 .total-text {
   font-size: 60px;
   color: #62B6CB;
-  text-shadow: 2px 2px 2px white;
+  // text-shadow: 2px 2px 2px white;
   font-family: Cabin Sketch;
 }

--- a/src/app/scrollbox/scrollbox.component.scss
+++ b/src/app/scrollbox/scrollbox.component.scss
@@ -10,8 +10,6 @@ li {
   border-radius: 6px;
   background-color: rgba(145, 230, 255, .4);
   border: 2px solid rgba(145, 230, 255, .1);
-  // background-color: rgba(190, 233, 232, .4);
-  // border: 2px solid rgba(190, 233, 232, .4);
   padding: 10px;
   margin: 10px;
   width: 320px;
@@ -21,7 +19,6 @@ li {
 #icon {
   font-size: 30px;
   color: white;
-  // color: #b7dcf7;
 }
 
 ::-webkit-scrollbar {
@@ -72,7 +69,6 @@ li {
 // Hover States
 
 li:hover{
-  // border: 2px solid white;
   border: 2px solid rgba(145, 230, 255, .4);
   background-color: rgba(145, 230, 255, .7);
 }

--- a/src/app/scrollbox/scrollbox.component.scss
+++ b/src/app/scrollbox/scrollbox.component.scss
@@ -8,8 +8,10 @@ p, ul, h2 {
 
 li {
   border-radius: 6px;
-  background-color: rgba(190, 233, 232, .4);
-  border: 2px solid rgba(190, 233, 232, .4);
+  background-color: rgba(145, 230, 255, .4);
+  border: 2px solid rgba(145, 230, 255, .1);
+  // background-color: rgba(190, 233, 232, .4);
+  // border: 2px solid rgba(190, 233, 232, .4);
   padding: 10px;
   margin: 10px;
   width: 320px;
@@ -18,7 +20,8 @@ li {
 
 #icon {
   font-size: 30px;
-  color: #b7dcf7;
+  color: white;
+  // color: #b7dcf7;
 }
 
 ::-webkit-scrollbar {
@@ -48,6 +51,7 @@ li {
 .loading-text {
   font-family: Cabin Sketch;
   font-size: 50px;
+  font-weight: normal;
 }
 
 .drink-price-text {
@@ -68,6 +72,7 @@ li {
 // Hover States
 
 li:hover{
-  border: 2px solid white;
-  background-color: rgba(190, 233, 232, .7);
+  // border: 2px solid white;
+  border: 2px solid rgba(145, 230, 255, .4);
+  background-color: rgba(145, 230, 255, .7);
 }

--- a/src/app/userpane/userpane.component.scss
+++ b/src/app/userpane/userpane.component.scss
@@ -90,7 +90,7 @@ h1, h2, h3, p {
   align-items: center;
   justify-content: space-around;
   background-color: rgba(145, 230, 255, .4);
-  border: 2px solid rgba(145, 230, 255, .4);
+  border: 2px solid rgba(145, 230, 255, .1);
 }
 
 .entry-form-inner {
@@ -113,7 +113,7 @@ h1, h2, h3, p {
   align-items: center;
   justify-content: space-around;
   background-color: rgba(145, 230, 255, .4);
-  border: 2px solid rgba(145, 230, 255, .4);
+  border: 2px solid rgba(145, 230, 255, .1);
   border-radius: 6px;
 }
 

--- a/src/app/userpane/userpane.component.scss
+++ b/src/app/userpane/userpane.component.scss
@@ -186,7 +186,6 @@ h1, h2, h3, p {
   font-size: 28px;
   color: #62B6CB;
   font-family: Cabin Sketch;
-  // text-shadow: 1px 1px 1px white;
 }
 
 // Hover States

--- a/src/app/userpane/userpane.component.scss
+++ b/src/app/userpane/userpane.component.scss
@@ -89,8 +89,8 @@ h1, h2, h3, p {
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  background-color: rgba(190, 233, 232, .4);
-  border: 2px solid rgba(190, 233, 232, .4);
+  background-color: rgba(145, 230, 255, .4);
+  border: 2px solid rgba(145, 230, 255, .4);
 }
 
 .entry-form-inner {
@@ -112,8 +112,8 @@ h1, h2, h3, p {
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  background-color: rgba(190, 233, 232, .4);
-  border: 2px solid rgba(190, 233, 232, .4);
+  background-color: rgba(145, 230, 255, .4);
+  border: 2px solid rgba(145, 230, 255, .4);
   border-radius: 6px;
 }
 
@@ -185,7 +185,8 @@ h1, h2, h3, p {
 .total-out-of-text {
   font-size: 28px;
   color: #62B6CB;
-  text-shadow: 1px 1px 1px white;
+  font-family: Cabin Sketch;
+  // text-shadow: 1px 1px 1px white;
 }
 
 // Hover States

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 @import url('https://fonts.googleapis.com/css?family=Cabin+Sketch');
 html, body {
-  background-color: #95E0F9;
+  background-color: black;
   background-image: url('https://i.imgur.com/we7Q26I.jpg');
   background-size: cover;
   background-repeat: no-repeat;


### PR DESCRIPTION
closes #60

-Updates background color to be black in case background image doesn't load.
-Updates the background color of the drink logs & forms, to look more blue & less green.
-Removes the white text shadow from all text on the dashboard.
-Changes wishing well icon URL to make sure color is correct.
-Removes bold for cabin sketch font text.
-Adds cabin sketch font to total text for the progress bar.

Below are screenshots of what the app currently looks like on this branch:
Dashboard
<img width="1349" alt="final_dashboard_screenshot" src="https://user-images.githubusercontent.com/37850013/55855062-add65a80-5b23-11e9-9667-527262dfb49c.png">



Log drink form
<img width="581" alt="Screen Shot 2019-04-10 at 12 03 34 AM" src="https://user-images.githubusercontent.com/37850013/55855416-b67b6080-5b24-11e9-9010-69b616ac9141.png">



Donation form
<img width="624" alt="Screen Shot 2019-04-10 at 12 03 49 AM" src="https://user-images.githubusercontent.com/37850013/55855432-c135f580-5b24-11e9-8b25-f1180e5aadbc.png">